### PR TITLE
Fixed exception handling in NukleusRule to avoid hiding test failure exceptions

### DIFF
--- a/src/main/java/org/reaktivity/reaktor/test/NukleusRule.java
+++ b/src/main/java/org/reaktivity/reaktor/test/NukleusRule.java
@@ -188,17 +188,40 @@ public final class NukleusRule implements TestRule
                     }
                 };
                 Thread caller = new Thread(runnable);
+                Throwable failure = null;
                 try
                 {
                     caller.start();
 
                     base.evaluate();
                 }
+                catch (Throwable t)
+                {
+                    failure = t;
+                }
                 finally
                 {
                     finished.set(true);
                     caller.join();
-                    assertEquals(0, errorCount.get());
+                    try
+                    {
+                        assertEquals(0, errorCount.get());
+                    }
+                    catch (Throwable t)
+                    {
+                        if (failure != null)
+                        {
+                            failure.addSuppressed(t);
+                        }
+                        else
+                        {
+                            failure = t;
+                        }
+                    }
+                    if (failure != null)
+                    {
+                        throw failure;
+                    }
                 }
             }
         };


### PR DESCRIPTION
when errorCount is non-zero. This condition is handled by adding the assertion error (for non zero error count) to the reported test exception as a suppressed exception. That way the test exception appears as the main exception so for example k3po differences can easily be viewed if that was the test exception.